### PR TITLE
Add beta tag

### DIFF
--- a/app/styles/_colors.scss
+++ b/app/styles/_colors.scss
@@ -1,3 +1,3 @@
 .bc-t-bg-grey-4 {
-    background-color: $color_nhsuk-grey-4;
+  background-color: $color_nhsuk-grey-4;
 }

--- a/app/styles/_tag.scss
+++ b/app/styles/_tag.scss
@@ -1,0 +1,17 @@
+.bc-c-tag {
+  color:  $color_nhsuk-white;
+  background-color: $color_nhsuk-blue;
+  padding: nhsuk-spacing(1) nhsuk-spacing(3);
+  font-weight: 600 !important;
+} 
+
+.bc-c-tag-foundation {
+  @extend .bc-c-tag;
+  display: inline-block;
+}
+
+.bc-c-tag-beta {
+  @extend .bc-c-tag;
+  float: left;
+  margin: nhsuk-spacing(2) nhsuk-spacing(3) 0 nhsuk-spacing(3);
+}

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -4,3 +4,4 @@
 // Application styles
 @import 'app';
 @import 'colors';
+@import 'tag';

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -1,10 +1,10 @@
 {% from 'components/header/macro.njk' import header %}
 {% from 'components/panel/macro.njk' import panel %}
 
-<div data-test-id="terms-banner">
+<span data-test-id="terms-banner">
   {{ panel({
     "colour": "grey",
-    "HTML": "<div>By using this site you are accepting the General Terms of Use which can be found <a href='pdf/terms.pdf' target='_blank'>here</a>. If you do not agree with these terms you should not use this website</div>",
+    "HTML": "<div class='nhsuk-grid-row'><div class='bc-c-tag-beta' data-test-id='beta-tag'>BETA</div><div data-test-id='terms-banner-text'>By using this site you are accepting the General Terms of Use which can be found <a href='pdf/terms.pdf' target='_blank'>here</a>. If you do not agree with these terms you should not use this website</div></div>",
     "classes": "nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-0 nhsuk-u-padding-top-3 nhsuk-u-padding-bottom-3 nhsuk-u-padding-left-0 nhsuk-width-container"
   }) }}
 </div>

--- a/app/views/includes/header.test.js
+++ b/app/views/includes/header.test.js
@@ -18,7 +18,7 @@ const createDummyApp = (context) => {
 
 
 describe('header', () => {
-  it('should render the header panel', (done) => {
+  it('should render the terms banner with beta tag', (done) => {
     const context = {};
 
     const app = createDummyApp(context);
@@ -27,7 +27,6 @@ describe('header', () => {
       .then((res) => {
         const $ = cheerio.load(res.text);
         const termsBanner = $('[data-test-id="terms-banner"] > div');
-
         expect(termsBanner.hasClass('nhsuk-u-margin-top-0')).toEqual(true);
         expect(termsBanner.hasClass('nhsuk-u-margin-bottom-0')).toEqual(true);
         expect(termsBanner.hasClass('nhsuk-u-padding-top-3')).toEqual(true);
@@ -36,7 +35,11 @@ describe('header', () => {
         expect(termsBanner.hasClass('nhsuk-panel--grey')).toEqual(true);
         expect(termsBanner.hasClass('nhsuk-width-container')).toEqual(true);
 
-        expect(termsBanner.text().trim()).toEqual('By using this site you are accepting the General Terms of Use which can be found here. If you do not agree with these terms you should not use this website');
+        const termsBannerText = $('[data-test-id="terms-banner-text"]');
+        expect(termsBannerText.text().trim()).toEqual('By using this site you are accepting the General Terms of Use which can be found here. If you do not agree with these terms you should not use this website');
+
+        const betaTag = $('[data-test-id="beta-tag"]');
+        expect(betaTag.hasClass('bc-c-tag-beta')).toEqual(true);
 
         done();
       });


### PR DESCRIPTION
Adds BETA tag to the terms banner.

I had to move the styles round a bit but they are more reuseable now.

<img width="1150" alt="Screenshot 2019-11-15 at 14 36 12" src="https://user-images.githubusercontent.com/30568078/68951088-4f5a1480-07b5-11ea-8b9a-cb54661b859a.png">
