### PR TITLE
Integration test 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ jspm_packages/
 # System Files
 .DS_Store
 Thumbs.db
+/.vs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- integration-test-2
+- master
 
 # no PR builds on this file
 pr: none
@@ -45,11 +45,14 @@ steps:
     azureContainerRegistry: '{"loginServer":"gpitfutureaksdev.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfuture-aks-dev/providers/Microsoft.ContainerRegistry/registries/gpitfutureaksdev"}'
     dockerComposeFile: '**/docker-compose.yml'
     action: 'Build services'
+    displayName: 'Build docker image'
 
-#- task: DockerCompose@0
-#  inputs:
-#    containerregistrytype: 'Azure Container Registry'
-#    azureSubscription: 'NHSAPP-BuyingCatalogue'
-#    azureContainerRegistry: '{"loginServer":"gpitfutureaksdev.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfuture-aks-dev/providers/Microsoft.ContainerRegistry/registries/gpitfutureaksdev"}'
-#    dockerComposeFile: '**/docker-compose.yml'
-#    action: 'Push services'
+
+- task: DockerCompose@0
+  inputs:
+    containerregistrytype: 'Azure Container Registry'
+    azureSubscription: 'NHSAPP-BuyingCatalogue'
+    azureContainerRegistry: '{"loginServer":"gpitfutureaksdev.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfuture-aks-dev/providers/Microsoft.ContainerRegistry/registries/gpitfutureaksdev"}'
+    dockerComposeFile: '**/docker-compose.yml'
+    action: 'Push services'
+    displayName: 'Publish docker image'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,10 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- master
+- integration-test-2
+
+# no PR builds on this file
+pr: none
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -21,7 +24,15 @@ steps:
     npm run test
     npm run test:integration
     npx webpack --config webpack.config.js
-  displayName: 'npm install, run webpack'
+  displayName: 'npm install, test, run webpack'
+
+- task: PublishTestResults@2
+  displayName: Publish integration test results
+  inputs:
+    testResultsFormat: NUnit
+    testResultsFiles: '$(System.DefaultWorkingDirectory)/integration-test-report.xml'
+    failTaskOnFailedTests: true
+  condition: succeededOrFailed()
 
 - task: DockerInstaller@0
   inputs:
@@ -35,10 +46,10 @@ steps:
     dockerComposeFile: '**/docker-compose.yml'
     action: 'Build services'
 
-- task: DockerCompose@0
-  inputs:
-    containerregistrytype: 'Azure Container Registry'
-    azureSubscription: 'NHSAPP-BuyingCatalogue'
-    azureContainerRegistry: '{"loginServer":"gpitfutureaksdev.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfuture-aks-dev/providers/Microsoft.ContainerRegistry/registries/gpitfutureaksdev"}'
-    dockerComposeFile: '**/docker-compose.yml'
-    action: 'Push services'
+#- task: DockerCompose@0
+#  inputs:
+#    containerregistrytype: 'Azure Container Registry'
+#    azureSubscription: 'NHSAPP-BuyingCatalogue'
+#    azureContainerRegistry: '{"loginServer":"gpitfutureaksdev.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfuture-aks-dev/providers/Microsoft.ContainerRegistry/registries/gpitfutureaksdev"}'
+#    dockerComposeFile: '**/docker-compose.yml'
+#    action: 'Push services'

--- a/package-lock.json
+++ b/package-lock.json
@@ -13770,6 +13770,7 @@
         "testcafe-reporter-minimal": "^2.1.0",
         "testcafe-reporter-spec": "^2.1.1",
         "testcafe-reporter-xunit": "^2.1.0",
+        "testcafe-reporter-nunit": "^0.1.2",
         "time-limit-promise": "^1.0.2",
         "tmp": "0.0.28",
         "tree-kill": "^1.1.0",
@@ -14144,6 +14145,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.1.0.tgz",
       "integrity": "sha1-5tZsVyzhWvJmcGrw/WELKoQd1EM="
+    },
+    "testcafe-reporter-nunit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-nunit/-/testcafe-reporter-nunit-0.1.2.tgz",
+      "integrity": "sha512-fUSBBHAg+5nCmVlIgcOzeXdAh9A8tn3rUs7MwYjHT6VEDst2kzkoPhu5Xg92X8PWNQp50sFQu5fYpot1iza/oQ==",
+      "requires": {
+        "mustache": "^2.2.1",
+        "read-file-relative": "^1.2.0"
+      }
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "express": "^4.17.1",
     "nunjucks": "^3.2.0",
     "path": "^0.12.7",
-    "testcafe": "^1.6.1"
+    "testcafe": "^1.6.1",
+    "testcafe-reporter-nunit": "^0.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.7.2",

--- a/testcafeRunner.js
+++ b/testcafeRunner.js
@@ -16,8 +16,12 @@ createTestcafe('localhost')
 
     return tc.createRunner()
       .src(['integration-tests/*.test.js', '**/*ui-test.js'])
-      .browsers('chrome')
+      .browsers('chrome:headless')
       .concurrency(2)
+      .reporter(['spec', {
+          name: 'nunit',
+          output: 'integration-test-report.xml'
+      }])
       .run();
   })
   .then((failCount) => {


### PR DESCRIPTION
Stumbled on that I can run the testcafe integration tests outside of docker by using headless chrome
Added task to pipeline yaml to publish the test result as the build wasn't picking up the test failures
Added PR trigger = None to stop us overwriting the docker image from feature branches
Added some display names to the docker compose tasks too

Test report can be viewed here: https://buyingcatalog.visualstudio.com/Buying%20Catalogue/_build/results?buildId=1244&view=ms.vss-test-web.build-test-results-tab