### PR TITLE
Readded publish test results tasks, with failTaskOnFailedTests set to…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,9 +32,27 @@ steps:
       npm run test
     displayName: 'Unit test'
 
+  - task: PublishTestResults@2
+  displayName: Publish unit test results
+  inputs:
+    testResultsFormat: NUnit
+    testResultsFiles: '$(System.DefaultWorkingDirectory)/unit-test-report.xml'
+    testRunTitle: Unit test results
+    failTaskOnFailedTests: false
+  condition: succeededOrFailed()
+
   - script: |
       npm run test:integration
     displayName: 'Integration test'
+
+  - task: PublishTestResults@2
+  displayName: Publish integration test results
+  inputs:
+    testResultsFormat: NUnit
+    testResultsFiles: '$(System.DefaultWorkingDirectory)/integration-test-report.xml'
+    testRunTitle: Integration test results
+    failTaskOnFailedTests: false
+  condition: succeededOrFailed()
 
   - task: DockerInstaller@0
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,26 +33,26 @@ steps:
     displayName: 'Unit test'
 
   - task: PublishTestResults@2
-  displayName: Publish unit test results
-  inputs:
-    testResultsFormat: NUnit
-    testResultsFiles: '$(System.DefaultWorkingDirectory)/unit-test-report.xml'
-    testRunTitle: Unit test results
-    failTaskOnFailedTests: false
-  condition: succeededOrFailed()
+    displayName: Publish unit test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: '$(System.DefaultWorkingDirectory)/unit-test-report.xml'
+      testRunTitle: Unit test results
+      failTaskOnFailedTests: false
+    condition: succeededOrFailed()
 
   - script: |
       npm run test:integration
     displayName: 'Integration test'
 
   - task: PublishTestResults@2
-  displayName: Publish integration test results
-  inputs:
-    testResultsFormat: NUnit
-    testResultsFiles: '$(System.DefaultWorkingDirectory)/integration-test-report.xml'
-    testRunTitle: Integration test results
-    failTaskOnFailedTests: false
-  condition: succeededOrFailed()
+    displayName: Publish integration test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: '$(System.DefaultWorkingDirectory)/integration-test-report.xml'
+      testRunTitle: Integration test results
+      failTaskOnFailedTests: false
+    condition: succeededOrFailed()
 
   - task: DockerInstaller@0
     inputs:


### PR DESCRIPTION
… false to it doesn't block the build.

Same as marketing pages
When we're happy with the integration tests and want to start failing the build when tests fail it will be a simple change