### PR TITLE
readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ npm install
 ## Running the application
 - Run - `npm run start`
 - Unit Tests - `npm run test`
-- Integration Tests On Linux - `npm run test:integration`
-- Integration Tests On Windows - `npm run test:integration_win`
+- Integration Tests - `npm run test:integration`
 
 Application should now be running on <a href="http://localhost:3000">http://localhost:3000</a>.
 


### PR DESCRIPTION
integration tests are now cross platform with 'cross-env' and there's no need for test:integration_win