### PR TITLE
3540 pb csrf

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,8 @@
 // Core dependencies
 const path = require('path');
 const favicon = require('serve-favicon');
+const csurf = require('csurf');
+const cookieParser = require('cookie-parser');
 
 // External dependencies
 const compression = require('compression');
@@ -31,6 +33,13 @@ export class App {
     this.app.use(bodyParser.urlencoded({ extended: true }));
 
     this.app.use(express.json());
+
+    // Middleware for csurf
+    const csrfMiddleware = csurf({
+      cookie: true,
+    });
+    this.app.use(cookieParser());
+    this.app.use(csrfMiddleware);
 
     // Middleware to serve static assets
     this.app.use(express.static(path.join(__dirname, 'public/')));

--- a/app/pages/capabilities-selector/template.njk
+++ b/app/pages/capabilities-selector/template.njk
@@ -13,6 +13,7 @@
     </div>
     <h1 class="nhsuk-u-margin-top-6 nhsuk-u-margin-bottom-4" data-test-id="capabilities-selector-page-title">{{ title }}</h1>
     <form method="post" action="/solutions/capabilities-selector">
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
       <div class="nhsuk-grid-row">
       <h2 class="nhsuk-u-font-size-22 nhsuk-u-padding-bottom-5 nhsuk-grid-column-two-thirds" data-test-id="capabilities-selector-page-description">{{ description }}</h2>
       {{ capabilitiesSelector({

--- a/app/routes.js
+++ b/app/routes.js
@@ -11,10 +11,11 @@ import config from './config';
 import includesContext from './includes/manifest.json';
 import { withCatch, getCapabilitiesParam } from './helpers/routerHelper';
 
-const addConfig = ({ context, user }) => ({
+const addConfig = ({ context, user, csrfToken }) => ({
   ...context,
   ...includesContext,
   username: user && user.id,
+  csrfToken,
   config,
 });
 
@@ -67,7 +68,7 @@ export const routes = (authProvider) => {
       if (!capabilities) {
         const context = await getCapabilitiesContext();
         logger.info('navigating to capabilities-selector page');
-        res.render('pages/capabilities-selector/template.njk', addConfig({ context, user: req.user }));
+        res.render('pages/capabilities-selector/template.njk', addConfig({ context, user: req.user, csrfToken: req.csrfToken() }));
       } else {
         const context = await getSolutionsForSelectedCapabilities({
           capabilitiesSelected: capabilities,

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -218,6 +218,15 @@ describe('routes', () => {
   });
 
   describe('POST /solutions/capabilities-selector', () => {
+    it('should return 403 forbidden if no csrf token is available', () => (
+      request(setUpFakeApp())
+        .post('/solutions/capabilities-selector')
+        .type('form')
+        .send({
+          capabilities: 'C1',
+        })
+        .expect(403)));
+
     it('should return the correct status and text if there is no error and one capability selected', async () => {
       capabilitiesContext.getCapabilitiesContext = jest.fn()
         .mockImplementation(() => Promise.resolve(mockCapabilitiesContext));

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -93,7 +93,6 @@ describe('routes', () => {
 
       return request(setUpFakeApp())
         .get('/')
-        .send({ _csrf: 'dada' })
         .expect(200)
         .then((res) => {
           expect(res.text.includes('<div class="nhsuk-hero" data-test-id="homepage-hero">')).toEqual(true);

--- a/app/routes.test.js
+++ b/app/routes.test.js
@@ -2,6 +2,7 @@ import request from 'supertest';
 import { App } from '../app';
 import { routes } from './routes';
 import { FakeAuthProvider } from './test-utils/FakeAuthProvider';
+import { getCsrfTokenFromGet } from './test-utils/helper';
 import * as homepageContext from './pages/homepage/context';
 import * as viewSolutionController from './pages/view-solution/controller';
 import * as solutionListPageContext from './pages/solutions-list/controller';
@@ -92,6 +93,7 @@ describe('routes', () => {
 
       return request(setUpFakeApp())
         .get('/')
+        .send({ _csrf: 'dada' })
         .expect(200)
         .then((res) => {
           expect(res.text.includes('<div class="nhsuk-hero" data-test-id="homepage-hero">')).toEqual(true);
@@ -156,7 +158,7 @@ describe('routes', () => {
         });
     });
 
-    it('should return the correct status and text if there is no error for capabilities-selector and capabilities are selected', () => {
+    it('should return the correct status and text if there is no error for capabilities-selector ', () => {
       capabilitiesContext.getCapabilitiesContext = jest.fn()
         .mockImplementation(() => Promise.resolve(mockCapabilitiesContext));
 
@@ -169,7 +171,7 @@ describe('routes', () => {
         });
     });
 
-    it('should return the correct status and text if there is no error for capabilities-selector with capabilities', () => {
+    it('should return the correct status and text if there is no error for capabilities-selector with capabilities and capabilities are selected', () => {
       solutionListPageContext.getSolutionsForSelectedCapabilities = jest.fn()
         .mockImplementation(() => Promise.resolve(mockFoundationSolutionsContext));
 
@@ -216,13 +218,23 @@ describe('routes', () => {
   });
 
   describe('POST /solutions/capabilities-selector', () => {
-    it('should return the correct status and text if there is no error and one capability selected', () => {
+    it('should return the correct status and text if there is no error and one capability selected', async () => {
+      capabilitiesContext.getCapabilitiesContext = jest.fn()
+        .mockImplementation(() => Promise.resolve(mockCapabilitiesContext));
+
       solutionListPageContext.getSolutionsForSelectedCapabilities = jest.fn()
         .mockImplementation(() => Promise.resolve(mockFilteredSolutions));
 
+      const { cookies, csrfToken } = await getCsrfTokenFromGet(setUpFakeApp(), '/solutions/capabilities-selector');
+
       return request(setUpFakeApp())
         .post('/solutions/capabilities-selector')
-        .send({ capabilities: 'C1' })
+        .type('form')
+        .set('Cookie', cookies)
+        .send({
+          capabilities: 'C1',
+          _csrf: csrfToken,
+        })
         .expect(302)
         .then((res) => {
           expect(res.redirect).toEqual(true);
@@ -230,13 +242,23 @@ describe('routes', () => {
         });
     });
 
-    it('should return the correct status and text if there is no error and many capabilities selected', () => {
+    it('should return the correct status and text if there is no error and many capabilities selected', async () => {
+      capabilitiesContext.getCapabilitiesContext = jest.fn()
+        .mockImplementation(() => Promise.resolve(mockCapabilitiesContext));
+
       solutionListPageContext.getSolutionsForSelectedCapabilities = jest.fn()
         .mockImplementation(() => Promise.resolve(mockFilteredSolutions));
 
+      const { cookies, csrfToken } = await getCsrfTokenFromGet(setUpFakeApp(), '/solutions/capabilities-selector');
+
       return request(setUpFakeApp())
         .post('/solutions/capabilities-selector')
-        .send({ capabilities: ['C1', 'C2', 'C3'] })
+        .type('form')
+        .set('Cookie', cookies)
+        .send({
+          capabilities: ['C1', 'C2', 'C3'],
+          _csrf: csrfToken,
+        })
         .expect(302)
         .then((res) => {
           expect(res.redirect).toEqual(true);
@@ -244,13 +266,23 @@ describe('routes', () => {
         });
     });
 
-    it('should return the correct status and text if there is no error and capabilities not selected', () => {
+    it('should return the correct status and text if there is no error and capabilities not selected', async () => {
+      capabilitiesContext.getCapabilitiesContext = jest.fn()
+        .mockImplementation(() => Promise.resolve(mockCapabilitiesContext));
+
       solutionListPageContext.getSolutionsForSelectedCapabilities = jest.fn()
         .mockImplementation(() => Promise.resolve(mockFilteredSolutions));
 
+      const { cookies, csrfToken } = await getCsrfTokenFromGet(setUpFakeApp(), '/solutions/capabilities-selector');
+
       return request(setUpFakeApp())
         .post('/solutions/capabilities-selector')
-        .send('all')
+        .type('form')
+        .set('Cookie', cookies)
+        .send({
+          capabilities: 'all',
+          _csrf: csrfToken,
+        })
         .expect(302)
         .then((res) => {
           expect(res.redirect).toEqual(true);

--- a/app/test-utils/helper.js
+++ b/app/test-utils/helper.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import cheerio from 'cheerio';
 import request from 'supertest';
 

--- a/app/test-utils/helper.js
+++ b/app/test-utils/helper.js
@@ -1,4 +1,25 @@
+import cheerio from 'cheerio';
+import request from 'supertest';
+
 export const extractInnerText = async (element) => {
   const elementInnerText = await element.innerText;
   return elementInnerText.trim();
 };
+
+export const extractCsrfToken = (res) => {
+  const $ = cheerio.load(res.text);
+  return $('[name=_csrf]').val();
+};
+
+export const getCsrfTokenFromGet = async (app, getPath) => {
+  let cookies;
+  let csrfToken;
+
+  await request(app)
+    .get(getPath)
+    .then((getRes) => {
+      cookies = getRes.headers['set-cookie'];
+      csrfToken = extractCsrfToken(getRes);
+    });
+  return { cookies, csrfToken };
+}

--- a/app/test-utils/helper.js
+++ b/app/test-utils/helper.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import cheerio from 'cheerio';
 import request from 'supertest';
 
@@ -22,4 +23,4 @@ export const getCsrfTokenFromGet = async (app, getPath) => {
       csrfToken = extractCsrfToken(getRes);
     });
   return { cookies, csrfToken };
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4704,6 +4704,16 @@
       "integrity": "sha1-zMjadQx1PH7curxUKWdHKjhOhrs=",
       "dev": true
     },
+    "csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "requires": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      }
+    },
     "css": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
@@ -4758,6 +4768,41 @@
       "dev": true,
       "requires": {
         "cssom": "0.3.x"
+      }
+    },
+    "csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+        },
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
       }
     },
     "cuint": {
@@ -11814,6 +11859,11 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -12306,6 +12356,11 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
     "rsvp": {
       "version": "4.8.5",
@@ -14985,6 +15040,14 @@
           "dev": true,
           "optional": true
         }
+      }
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
       }
     },
     "ultron": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.4",
     "cookie-session": "^1.4.0",
+    "csurf": "^1.11.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "nhsuk-frontend": "^3.0.2",


### PR DESCRIPTION
add csrf security to public browse. Sets a token on the form. A hidden input field is used to store this token and then this is then passed on when the form is submitted. The app will then check this token matches the one it sent in the request to make sure no dodgy business has gone down.