### PR TITLE
5801 - BUG - Documents not downloading

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -116,7 +116,9 @@ export const routes = (authProvider) => {
   router.get('/solutions/:filterType.:capabilities?/:solutionId/document/:documentName', async (req, res) => {
     const { solutionId, documentName } = req.params;
     logger.info(`downloading Solution ${solutionId} document ${documentName}`);
+    const documentType = documentName.split('.')[1];
     const response = await getDocument({ solutionId, documentName });
+    res.setHeader('Content-type', `application/${documentType}`);
     response.data.pipe(res);
   });
 


### PR DESCRIPTION
Looks like we need to set the content-type needs to be set on the response for public browse.

Also the unit test for the document download route is poor. I've added a tech-debt ticket https://buyingcatalog.visualstudio.com/Buying%20Catalogue/_workitems/edit/5853 to look into this. The unit test in the route for this is not even testing the route.

Seems to work with a pdf type doc. Need to investigate with other document types. May have to do some mapping to the necessary content-type. Eg `.jpg` is `octet-stream`